### PR TITLE
cleanup: env var consistency, uiax.server namespace, macOS PM fix, pyatspi guidance, GTK4 keystroke fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ any windowed app — just like a human operator.
 
 The recommended deployment: serve over HTTP with a generated API key.
 
+**Windows (PowerShell)**
+
 ```powershell
 # 1. Clone and install
 git clone https://github.com/doucej/uia-x.git
@@ -26,35 +28,97 @@ pip install -e .
 
 # 2. Start the server  (prints the active API key to stdout at startup)
 $env:MCP_TRANSPORT="streamable-http"
-python -m server.server
+python -m uiax.server
+```
+
+**Linux**
+
+> **Note:** pyatspi must be visible to the Python interpreter you use.  If
+> you are running inside a virtualenv, either create it with
+> `--system-site-packages` or use the system Python directly.
+
+```bash
+# 1. Install the OS-level AT-SPI2 library
+sudo apt install python3-pyatspi gir1.2-atspi-2.0 at-spi2-core
+
+# 2. Clone and install (system Python, so pyatspi is visible)
+git clone https://github.com/doucej/uia-x.git
+cd uia-x
+python3 -m venv --system-site-packages .venv
+source .venv/bin/activate
+pip install -e .
+
+# 3. Start the server
+export MCP_TRANSPORT=streamable-http
+python -m uiax.server
+```
+
+**macOS**
+
+```bash
+# 1. Clone and install
+git clone https://github.com/doucej/uia-x.git
+cd uia-x
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e .
+
+# 2. Grant Accessibility access to Terminal (System Settings → Privacy & Security
+#    → Accessibility) so AXAPI can inspect other apps.
+
+# 3. Start the server
+export MCP_TRANSPORT=streamable-http
+python -m uiax.server
 ```
 
 On **first** startup (new key generated and hash saved to disk):
 
 ```
-[uia-x] *** NEW API KEY GENERATED ***
-[uia-x] Key: <your-key>
-[uia-x] Stored hash in: C:\Users\<you>\.uia_x\api_key
-[uia-x] Save this key – it will not be shown again.
+[uiax] *** NEW API KEY GENERATED ***
+[uiax] Key: <your-key>
+[uiax] Stored hash in: ~/.uiax/api_key
+[uiax] Save this key – it will not be shown again.
+[uiax] To rotate the key run: uiax-server --reset-key
 [uiax] starting server (backend=real, auth=apikey, transport=streamable-http, http://0.0.0.0:8000)
 ```
+
+The key file lives under your home directory on every platform:
+
+| Platform | Path |
+|----------|------|
+| Windows | `C:\Users\<you>\.uiax\api_key` |
+| Linux | `/home/<you>/.uiax/api_key` |
+| macOS | `/Users/<you>/.uiax/api_key` |
 
 On **subsequent** startups (hash loaded from disk — plaintext not recoverable):
 
 ```
-[uia-x] API key loaded from disk (C:\Users\<you>\.uia_x\api_key).
-[uia-x] The hash is stored; use your saved key to authenticate.
-[uia-x] To display the key again set UIAX_API_KEY=<your-key> or delete the file to regenerate.
+[uiax] API key loaded from disk (~/.uiax/api_key).
+[uiax] The hash is stored; use your saved key to authenticate.
+[uiax] To display the key again set UIAX_API_KEY=<your-key> or delete the file to regenerate.
+[uiax] To rotate the key run: uiax-server --reset-key
 [uiax] starting server (backend=real, auth=apikey, transport=streamable-http, http://0.0.0.0:8000)
+```
+
+To rotate the key at any time:
+
+```bash
+uiax-server --reset-key   # generates and saves a new key, then exits
 ```
 
 To pin a fixed key that is printed on every startup, set `UIAX_API_KEY`:
 
-```powershell
+```bash
+# Linux / macOS
+export UIAX_API_KEY="my-fixed-key"
+python -m uiax.server
+
+# Windows (PowerShell)
 $env:UIAX_API_KEY="my-fixed-key"
-python -m server.server
-# [uia-x] API key sourced from environment variable UIAX_API_KEY.
-# [uia-x] Key: my-fixed-key
+python -m uiax.server
+
+# [uiax] API key sourced from environment variable UIAX_API_KEY.
+# [uiax] Key: my-fixed-key
 ```
 
 **3. Point your MCP client at `http://localhost:8000/mcp`** and pass the API
@@ -69,9 +133,9 @@ key as a Bearer token header or as the `api_key` parameter on each tool call.
 | `MCP_TRANSPORT` | `stdio` | Transport: `stdio`, `sse`, `streamable-http` |
 | `MCP_HOST` | `0.0.0.0` | Bind address (HTTP modes) |
 | `MCP_PORT` | `8000` | Listen port (HTTP modes) |
-| `UIA_X_AUTH` | `apikey` | Auth mode: `apikey` or `none` |
+| `UIAX_AUTH` | `apikey` | Auth mode: `apikey` or `none`. Legacy alias: `UIA_X_AUTH` |
 | `UIAX_API_KEY` | *(auto)* | Pin a specific API key (skips on-disk generation). Legacy alias: `UIA_X_API_KEY` |
-| `UIA_BACKEND` | `real` | Backend: `real` (auto-detect), `linux` (AT-SPI2), `macos` (AXAPI), or `mock` (tests) |
+| `UIAX_BACKEND` | `real` | Backend: `real` (auto-detect), `linux` (AT-SPI2), `macos` (AXAPI), or `mock` (tests). Legacy alias: `UIA_BACKEND` |
 
 ---
 
@@ -81,7 +145,7 @@ key as a Bearer token header or as the `api_key` parameter on each tool call.
 > block in your client config simply tells the client what credentials to
 > present — the server decides whether to accept them.  A client that omits
 > or forges the header is rejected with a 401.  If the server is started with
-> `UIA_X_AUTH=none`, no credentials are checked regardless of what the client
+> `UIAX_AUTH=none`, no credentials are checked regardless of what the client
 > sends.
 
 UIA-X supports **two ways** to present an API key — use whichever
@@ -103,14 +167,31 @@ is ignored (you can omit it).
 
 Stdio — the server runs as a local subprocess. No key needed.
 
+**Windows:**
+
 ```json
 {
   "mcpServers": {
     "uiax": {
-      "command": "python",
-      "args": ["-m", "server.server"],
+      "command": "C:/path/to/uia-x/.venv/Scripts/python.exe",
+      "args": ["-m", "uiax.server"],
       "cwd": "C:/path/to/uia-x",
-      "env": { "UIA_X_AUTH": "none" }
+      "env": { "UIAX_AUTH": "none" }
+    }
+  }
+}
+```
+
+**Linux / macOS:**
+
+```json
+{
+  "mcpServers": {
+    "uiax": {
+      "command": "/path/to/uia-x/.venv/bin/python",
+      "args": ["-m", "uiax.server"],
+      "cwd": "/path/to/uia-x",
+      "env": { "UIAX_AUTH": "none" }
     }
   }
 }
@@ -126,9 +207,11 @@ Stdio — no API key required.
   "servers": {
     "uiax": {
       "type": "stdio",
+      // Windows: "${workspaceFolder}/.venv/Scripts/python.exe"
+      // Linux / macOS: "${workspaceFolder}/.venv/bin/python"
       "command": "${workspaceFolder}/.venv/Scripts/python.exe",
-      "args": ["-m", "server.server"],
-      "env": { "UIA_X_AUTH": "none", "UIA_BACKEND": "real" }
+      "args": ["-m", "uiax.server"],
+      "env": { "UIAX_AUTH": "none", "UIAX_BACKEND": "real" }
     }
   }
 }
@@ -183,7 +266,7 @@ opencode uses `"type": "remote"` for HTTP MCP servers.
 }
 ```
 
-**Without auth (local dev)** — start the server with `UIA_X_AUTH=none` and
+**Without auth (local dev)** — start the server with `UIAX_AUTH=none` and
 omit the `headers` block:
 
 ```jsonc
@@ -198,7 +281,7 @@ omit the `headers` block:
 ```
 
 > **Note:** opencode stores the key in plain text (no `${input:...}` prompt
-> like VS Code).  For local-only use, running with `UIA_X_AUTH=none` is the
+> like VS Code).  For local-only use, running with `UIAX_AUTH=none` is the
 > simplest path.  For remote/shared servers, treat the config file as
 > sensitive.
 
@@ -213,7 +296,7 @@ curl -H "Authorization: Bearer <your-api-key>" \
      http://<host>:8000/mcp
 ```
 
-If auth is disabled server-side (`UIA_X_AUTH=none`), just hit the URL
+If auth is disabled server-side (`UIAX_AUTH=none`), just hit the URL
 directly — no header needed.
 
 ---
@@ -442,7 +525,7 @@ Every time the server starts it resolves the active API key and prints status
 to **stdout** before the HTTP server begins accepting connections:
 
 * **First run** – a new cryptographically random key is generated, its
-  SHA-256 hash is written to `~/.uia_x/api_key`, and the **plaintext key** is
+  SHA-256 hash is written to `~/.uiax/api_key`, and the **plaintext key** is
   printed.  Copy and save it — the file stores only the hash, so the
   plaintext cannot be recovered on subsequent runs.
 * **Subsequent runs** – the hash is loaded from disk and a confirmation
@@ -482,15 +565,15 @@ Every tool also accepts `api_key` as a parameter:
 ### Disabling auth (local dev)
 
 ```bash
-UIA_X_AUTH=none python -m server.server
+UIAX_AUTH=none python -m uiax.server
 ```
 
 ### Overriding the key via environment
 
 ```bash
-UIAX_API_KEY=my-fixed-key python -m server.server
+UIAX_API_KEY=my-fixed-key python -m uiax.server
 # Legacy alias also accepted:
-UIA_X_API_KEY=my-fixed-key python -m server.server
+UIA_X_API_KEY=my-fixed-key python -m uiax.server
 ```
 
 ### Future auth methods
@@ -504,19 +587,30 @@ provider by implementing the `AuthProvider` protocol in `server/auth.py`.
 
 **Against a live desktop (stdio, default):**
 ```bash
-python -m server.server
+# Linux / macOS
+python -m uiax.server
+
+# Windows (PowerShell)
+python -m uiax.server
 ```
 
 **HTTP mode (recommended for remote / multi-client):**
+```bash
+# Linux / macOS
+export MCP_TRANSPORT=streamable-http
+python -m uiax.server
+# → Listening on http://0.0.0.0:8000/mcp
+```
 ```powershell
+# Windows (PowerShell)
 $env:MCP_TRANSPORT="streamable-http"
-python -m server.server
+python -m uiax.server
 # → Listening on http://0.0.0.0:8000/mcp
 ```
 
-**Mock backend (no Windows required):**
+**Mock backend (no desktop required — for testing):**
 ```bash
-UIA_BACKEND=mock python -m server.server
+UIAX_BACKEND=mock python -m uiax.server
 ```
 
 ---
@@ -562,8 +656,8 @@ contains only the target application(s).
 5. **Start UIA-X** inside the VM session:
    ```powershell
    $env:MCP_TRANSPORT = "streamable-http"
-   $env:UIA_X_AUTH    = "apikey"        # or "none" for local-only
-   python -m server.server
+   $env:UIAX_AUTH     = "apikey"        # or "none" for local-only
+   python -m uiax.server
    ```
 6. **Connect your MCP client** from your host to `http://<vm-ip>:8000/mcp`.
 
@@ -595,7 +689,7 @@ RUN pip install -r requirements.txt
 CMD Xvfb :99 -screen 0 1920x1080x24 & \
     export DISPLAY=:99 && \
     export MCP_TRANSPORT=streamable-http && \
-    dbus-run-session -- python -m server.server
+    dbus-run-session -- python -m uiax.server
 ```
 
 ```bash
@@ -786,7 +880,7 @@ element):
 The `"Display is "` prefix is part of the UWP Calculator’s accessible name.
 Skill guides should document this pattern so the model knows to strip it.
 
-> *Required unless `UIA_X_AUTH=none`.
+> *Required unless `UIAX_AUTH=none`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ python -m uiax.server
 > `--system-site-packages` or use the system Python directly.
 
 ```bash
-# 1. Install the OS-level AT-SPI2 library
-sudo apt install python3-pyatspi gir1.2-atspi-2.0 at-spi2-core
+# 1. Install system dependencies (AT-SPI2 + venv support for system Python)
+sudo apt install python3-pyatspi gir1.2-atspi-2.0 at-spi2-core python3-venv
 
 # 2. Clone and install (system Python, so pyatspi is visible)
 git clone https://github.com/doucej/uia-x.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
 ]
 
 [project.scripts]
-uiax-server = "server.server:main"
+uiax-server = "uiax.server:main"
 
 [project.urls]
 Homepage = "https://github.com/doucej/uia-x"

--- a/server/auth.py
+++ b/server/auth.py
@@ -14,8 +14,9 @@ Design
 
 Disabling auth
 --------------
-Set the environment variable ``UIA_X_AUTH=none`` to skip all
+Set the environment variable ``UIAX_AUTH=none`` to skip all
 authentication checks (useful for local-only / dev usage).
+``UIA_X_AUTH`` is a deprecated alias that still works.
 """
 
 from __future__ import annotations
@@ -35,11 +36,12 @@ from server.uia_bridge import AuthenticationError
 # Config
 # ---------------------------------------------------------------------------
 
-_CONFIG_DIR = Path.home() / ".uia_x"
+_CONFIG_DIR = Path.home() / ".uiax"
 _KEY_FILE = _CONFIG_DIR / "api_key"
-_ENV_AUTH_MODE = "UIA_X_AUTH"         # "apikey" (default) | "none"
+_ENV_AUTH_MODE = "UIAX_AUTH"           # "apikey" (default) | "none" (primary)
+_ENV_AUTH_MODE_LEGACY = "UIA_X_AUTH"   # deprecated alias – still accepted
 _ENV_API_KEY = "UIAX_API_KEY"         # primary override key from env
-_ENV_API_KEY_LEGACY = "UIA_X_API_KEY" # backward-compat alias
+_ENV_API_KEY_LEGACY = "UIA_X_API_KEY" # deprecated alias – still accepted
 
 
 # ---------------------------------------------------------------------------
@@ -158,17 +160,21 @@ def get_auth_provider() -> AuthProvider:
     Build the appropriate AuthProvider based on environment / config.
 
     Priority:
-    1. ``UIA_X_AUTH=none``  → NoAuthProvider
-    2. ``UIAX_API_KEY`` env var (or legacy ``UIA_X_API_KEY``) → ApiKeyProvider
+    1. ``UIAX_AUTH=none`` (or deprecated ``UIA_X_AUTH=none``) → NoAuthProvider
+    2. ``UIAX_API_KEY`` env var (or deprecated ``UIA_X_API_KEY``) → ApiKeyProvider
     3. Key hash on disk    → ApiKeyProvider  (key shown on first-run only)
     4. No key yet          → generate one, print to **stdout**, persist hash
     """
-    mode = os.environ.get(_ENV_AUTH_MODE, "apikey").lower()
+    mode = (
+        os.environ.get(_ENV_AUTH_MODE, "").lower()
+        or os.environ.get(_ENV_AUTH_MODE_LEGACY, "").lower()
+        or "apikey"
+    )
     if mode == "none":
         return NoAuthProvider()
 
-    # Check env-var override (UIAX_API_KEY takes precedence; UIA_X_API_KEY is
-    # a backward-compatible alias kept for existing deployments).
+    # Check env-var override (UIAX_API_KEY takes precedence;
+    # UIA_X_API_KEY is a deprecated backward-compatible alias).
     env_key = (
         os.environ.get(_ENV_API_KEY, "").strip()
         or os.environ.get(_ENV_API_KEY_LEGACY, "").strip()
@@ -182,8 +188,8 @@ def get_auth_provider() -> AuthProvider:
             else ""
         )
         print(
-            f"[uia-x] API key sourced from environment variable {env_var_used}{disk_note}.\n"
-            f"[uia-x] Key: {env_key}",
+            f"[uiax] API key sourced from environment variable {env_var_used}{disk_note}.\n"
+            f"[uiax] Key: {env_key}",
             file=sys.stdout,
         )
         return ApiKeyProvider(key_hash)
@@ -193,10 +199,11 @@ def get_auth_provider() -> AuthProvider:
     stored_hash = load_key_hash()
     if stored_hash:
         print(
-            f"[uia-x] API key loaded from disk ({_KEY_FILE}).\n"
-            f"[uia-x] The hash is stored; use your saved key to authenticate.\n"
-            f"[uia-x] To display the key again set {_ENV_API_KEY}=<your-key> "
-            f"or delete {_KEY_FILE} to generate a new one.",
+            f"[uiax] API key loaded from disk ({_KEY_FILE}).\n"
+            f"[uiax] The hash is stored; use your saved key to authenticate.\n"
+            f"[uiax] To display the key again set {_ENV_API_KEY}=<your-key> "
+            f"or delete {_KEY_FILE} to generate a new one.\n"
+            f"[uiax] To rotate the key run: uiax-server --reset-key",
             file=sys.stdout,
         )
         return ApiKeyProvider(stored_hash)
@@ -204,10 +211,11 @@ def get_auth_provider() -> AuthProvider:
     # First-run: generate a new key, persist the hash, display the plaintext.
     raw_key = generate_api_key()
     print(
-        f"[uia-x] *** NEW API KEY GENERATED ***\n"
-        f"[uia-x] Key: {raw_key}\n"
-        f"[uia-x] Stored hash in: {_KEY_FILE}\n"
-        f"[uia-x] Save this key – it will not be shown again.",
+        f"[uiax] *** NEW API KEY GENERATED ***\n"
+        f"[uiax] Key: {raw_key}\n"
+        f"[uiax] Stored hash in: {_KEY_FILE}\n"
+        f"[uiax] Save this key – it will not be shown again.\n"
+        f"[uiax] To rotate the key run: uiax-server --reset-key",
         file=sys.stdout,
     )
     return ApiKeyProvider(hashlib.sha256(raw_key.encode()).hexdigest())

--- a/server/process_manager.py
+++ b/server/process_manager.py
@@ -3,12 +3,11 @@ Process and window manager – enumerate running processes, their top-level
 windows, and attach to a specific process/window as the active automation
 target.
 
-Operates in two modes:
-  * **real** – uses ctypes/psutil/pywinauto to query the live system
-  * **mock** – returns canned data for unit tests
-
-The manager is a singleton within the server process; tools call
-``get_process_manager()`` to obtain it.
+Operates in several modes:
+  * **real**   – auto-detects platform and delegates to the appropriate backend
+  * **mock**   – returns canned data for unit tests
+  * **linux**  – force AT-SPI2 backend (Linux)
+  * **macos**  – force AXAPI backend (macOS)
 """
 
 from __future__ import annotations
@@ -311,6 +310,61 @@ class LinuxProcessManagerAdapter(ProcessManager):
 
 
 # ---------------------------------------------------------------------------
+# macOS AXAPI adapter
+# ---------------------------------------------------------------------------
+
+
+class MacOSProcessManagerAdapter(ProcessManager):
+    """
+    Adapter that wraps :class:`uiax.backends.macos.bridge.MacOSProcessManager`
+    to conform to the :class:`ProcessManager` ABC.
+
+    Translates AXAPI window dicts into :class:`WindowInfo` instances.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        from uiax.backends.macos.bridge import get_macos_process_manager  # noqa: PLC0415
+
+        self._mpm = get_macos_process_manager()
+
+    def list_windows(self, *, visible_only: bool = True) -> list[WindowInfo]:
+        raw = self._mpm.list_windows(visible_only=visible_only)
+        return [self._to_window_info(w) for w in raw]
+
+    def attach(
+        self,
+        *,
+        pid: int | None = None,
+        process_name: str | None = None,
+        window_title: str | None = None,
+        class_name: str | None = None,
+        hwnd: int | None = None,
+    ) -> WindowInfo:
+        win = self._mpm.attach(
+            pid=pid,
+            process_name=process_name,
+            window_title=window_title,
+            class_name=class_name,
+            hwnd=hwnd,
+        )
+        self._attached = self._to_window_info(win)
+        return self._attached
+
+    @staticmethod
+    def _to_window_info(w: dict) -> WindowInfo:
+        return WindowInfo(
+            hwnd=w.get("hwnd", 0),
+            title=w.get("title", ""),
+            class_name=w.get("class_name", ""),
+            pid=w.get("pid", 0),
+            process_name=w.get("process_name", ""),
+            visible=w.get("visible", True),
+            rect=w.get("rect", {"left": 0, "top": 0, "right": 0, "bottom": 0}),
+        )
+
+
+# ---------------------------------------------------------------------------
 # Default mock fixtures
 # ---------------------------------------------------------------------------
 
@@ -362,13 +416,18 @@ def get_process_manager(backend: str | None = None) -> ProcessManager:
     global _instance
     if _instance is None:
         if backend is None:
-            backend = os.environ.get("UIA_BACKEND", "real").lower()
+            backend = (
+                os.environ.get("UIAX_BACKEND", "")
+                or os.environ.get("UIA_BACKEND", "real")
+            ).lower()
         if backend == "mock":
             _instance = MockProcessManager()
         elif backend == "linux" or (backend == "real" and _is_linux()):
             _instance = LinuxProcessManagerAdapter()
+        elif backend == "macos" or (backend == "real" and _is_macos()):
+            _instance = MacOSProcessManagerAdapter()
         else:
-            _instance = RealProcessManager()
+            _instance = RealProcessManager()  # Windows
     return _instance
 
 
@@ -377,6 +436,13 @@ def _is_linux() -> bool:
     import sys  # noqa: PLC0415
 
     return sys.platform.startswith("linux")
+
+
+def _is_macos() -> bool:
+    """Return True if the current platform is macOS."""
+    import sys  # noqa: PLC0415
+
+    return sys.platform == "darwin"
 
 
 def reset_process_manager() -> None:

--- a/server/server.py
+++ b/server/server.py
@@ -1,19 +1,30 @@
 """
-Main MCP server entry point – V2: Windows UI Automation substrate.
+Main MCP server entry point – cross-platform UI Automation over MCP.
 
-Generalised beyond any single application.  Use the ``process_list`` and
-``select_window`` tools to choose a target window, then use the UIA tools
-to inspect and interact with it.
+Use the ``process_list`` and ``select_window`` tools to choose a target window,
+then use the UIA tools to inspect and interact with it.
 
 Environment variables
 ---------------------
-UIA_BACKEND       "real" (default) or "mock"
-UIA_X_AUTH    "apikey" (default) or "none"
-UIA_X_API_KEY Override API key (skip on-disk generation)
+UIAX_BACKEND      Backend: ``real`` (auto-detect, default), ``mock``, ``linux``,
+                  ``macos``.  Legacy alias: ``UIA_BACKEND``.
+UIAX_AUTH         Auth mode: ``apikey`` (default) or ``none``.
+                  Legacy alias: ``UIA_X_AUTH``.
+UIAX_API_KEY      Pin a specific API key (printed on startup; skips on-disk keygen).
+                  Deprecated alias: ``UIA_X_API_KEY``.
+MCP_TRANSPORT     Transport: ``stdio`` (default), ``sse``, ``streamable-http``.
+MCP_HOST          Bind address for HTTP transports (default ``0.0.0.0``).
+MCP_PORT          Port for HTTP transports (default ``8000``).
 
-Usage:
-    python -m server.server
-    UIA_BACKEND=mock python -m server.server
+Usage
+-----
+    python -m uiax.server
+    UIAX_BACKEND=mock python -m uiax.server
+    UIAX_AUTH=none MCP_TRANSPORT=streamable-http python -m uiax.server
+
+Key rotation
+------------
+    uiax-server --reset-key   # delete stored hash and generate a new key
 """
 
 from __future__ import annotations
@@ -66,7 +77,10 @@ _bridge = None
 def _get_bridge():
     global _bridge
     if _bridge is None:
-        backend = os.environ.get("UIA_BACKEND", "real").lower()
+        backend = (
+            os.environ.get("UIAX_BACKEND", "")
+            or os.environ.get("UIA_BACKEND", "real")
+        ).lower()
         _bridge = get_bridge(backend)
     return _bridge
 
@@ -675,11 +689,32 @@ def main() -> None:
     # parse_known_args so MCP-client-injected arguments don't cause a hard error.
     args, _ = parser.parse_known_args()
 
-    backend = os.environ.get("UIA_BACKEND", "real").lower()
-    auth_mode = os.environ.get("UIA_X_AUTH", "apikey").lower()
+    backend = (
+        os.environ.get("UIAX_BACKEND", "")
+        or os.environ.get("UIA_BACKEND", "real")
+    ).lower()
+    auth_mode = (
+        os.environ.get("UIAX_AUTH", "")
+        or os.environ.get("UIA_X_AUTH", "apikey")
+    ).lower()
     transport = os.environ.get("MCP_TRANSPORT", "stdio").lower()
     host = os.environ.get("MCP_HOST", "0.0.0.0")
     port = int(os.environ.get("MCP_PORT", "8000"))
+
+    # Early warning on Linux if AT-SPI2 bindings are not importable.
+    if sys.platform.startswith("linux") and backend in ("real", "linux"):
+        try:
+            import pyatspi  # noqa: F401
+        except ImportError:
+            print(
+                "[uiax] WARNING: python3-pyatspi not found.\n"
+                "[uiax] Linux AT-SPI2 automation requires the system package:\n"
+                "[uiax]   sudo apt install python3-pyatspi gir1.2-atspi-2.0 at-spi2-core\n"
+                "[uiax] If running in a venv, either:\n"
+                "[uiax]   a) Create the venv with --system-site-packages, or\n"
+                "[uiax]   b) Use the system Python directly (python3 -m uiax.server)",
+                file=sys.stderr,
+            )
 
     if args.reset_key:
         deleted = delete_key_file()

--- a/tests/mcp_live_test.py
+++ b/tests/mcp_live_test.py
@@ -1,0 +1,156 @@
+"""
+Live MCP server integration test against gnome-calculator.
+
+Exercises the full stack:
+  process_list → select_window → uia_inspect → uia_invoke (buttons) → uia_inspect result
+
+Run with:
+  .uiax/bin/python tests/mcp_live_test.py
+(server must be running on http://localhost:8765 with UIAX_AUTH=none)
+"""
+import asyncio
+import json
+import sys
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+
+SERVER_URL = "http://localhost:8765/mcp"
+
+
+async def call(session: ClientSession, tool: str, **kwargs) -> dict:
+    result = await session.call_tool(tool, kwargs)
+    # FastMCP returns a list of TextContent items
+    raw = result.content[0].text if result.content else "{}"
+    try:
+        data = json.loads(raw)
+        # Unwrap {"ok": true, "element": {...}} envelope when present
+        if isinstance(data, dict) and "element" in data:
+            return data["element"]
+        return data
+    except json.JSONDecodeError:
+        return {"_raw": raw}
+
+
+async def main() -> None:
+    async with streamablehttp_client(SERVER_URL) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            # ----------------------------------------------------------------
+            # 1. List available tools
+            # ----------------------------------------------------------------
+            tools = await session.list_tools()
+            tool_names = [t.name for t in tools.tools]
+            print(f"[tools] {tool_names}\n")
+
+            # ----------------------------------------------------------------
+            # 2. List processes / windows
+            # ----------------------------------------------------------------
+            procs = await call(session, "process_list")
+            windows = procs.get("windows", [])
+            calc_win = next(
+                (w for w in windows if "calculator" in w.get("title", "").lower()),
+                None,
+            )
+            if not calc_win:
+                print("ERROR: Calculator not found in process list")
+                print("Windows:", [w.get("title") for w in windows])
+                sys.exit(1)
+            print(f"[process_list] found: {calc_win['title']}  pid={calc_win['pid']}")
+
+            # ----------------------------------------------------------------
+            # 3. Select (attach to) the calculator window
+            # ----------------------------------------------------------------
+            sel = await call(session, "select_window", hwnd=calc_win["hwnd"])
+            print(f"[select_window] {sel}\n")
+
+            # ----------------------------------------------------------------
+            # 4. Inspect root to confirm we have the right window
+            # ----------------------------------------------------------------
+            root = await call(session, "uia_inspect", target={"depth": 2})
+            print(f"[uia_inspect root] name={root.get('name')!r}  role={root.get('role')!r}")
+            print(f"  children: {[c.get('name') or c.get('role') for c in root.get('children', [])]}\n")
+
+            # ----------------------------------------------------------------
+            # 5. Clear the calculator
+            # ----------------------------------------------------------------
+            for clear_name in ("C", "Clear", "AC"):
+                try:
+                    r = await call(session, "uia_invoke", target={"by": "name", "value": clear_name})
+                    print(f"[clear] invoked {clear_name!r}: {r}")
+                    await asyncio.sleep(0.3)
+                    break
+                except Exception:
+                    pass
+
+            # ----------------------------------------------------------------
+            # 6. Press 7 × 6 = via uia_invoke (AT-SPI click on each button)
+            # ----------------------------------------------------------------
+            sequence = [("7", "7"), ("×", "×"), ("6", "6"), ("=", "=")]
+            for btn_name, label in sequence:
+                result = await call(session, "uia_invoke", target={"by": "name", "value": btn_name})
+                print(f"[uia_invoke] {label!r} → {result}")
+                await asyncio.sleep(0.3)
+
+            # ----------------------------------------------------------------
+            # 7. Read the result from the AT-SPI tree
+            # ----------------------------------------------------------------
+            print()
+            # Strategy 1: look for an element whose name contains "42"
+            try:
+                found = await call(session, "uia_inspect", target={"by": "name_substring", "value": "42"})
+                for field in ("text", "name", "value"):
+                    v = found.get(field, "")
+                    if v and "42" in str(v):
+                        print(f"[result] ✓  Found '42' via field={field!r}: {v!r}")
+                        return
+            except Exception as e:
+                print(f"[result] name_substring search failed: {e}")
+
+            # Strategy 2: deep tree dump
+            deep = await call(session, "uia_inspect", target={"depth": 20})
+            result_text = _find_result(deep)
+            if result_text and "42" in result_text:
+                print(f"[result] ✓  Found '42' in deep tree: {result_text!r}")
+            elif result_text:
+                print(f"[result] ✗  Deep tree found number but not 42: {result_text!r}")
+            else:
+                print("[result] ✗  Could not find numeric result in tree")
+                print("[debug] deep tree:")
+                _dump(deep)
+
+
+def _find_result(node: dict, depth: int = 0) -> str | None:
+    role = node.get("role", "")
+    if role in ("push button", "button", "toggle button"):
+        return None
+    for field in ("text", "value", "name"):
+        v = str(node.get(field) or "")
+        if v and any(c.isdigit() for c in v):
+            return v
+    for child in node.get("children", []):
+        found = _find_result(child, depth + 1)
+        if found:
+            return found
+    return None
+
+
+def _dump(node: dict, indent: int = 0) -> None:
+    prefix = "  " * indent
+    role = node.get("role", "?")
+    name = node.get("name", "")
+    text = node.get("text", "")
+    value = node.get("value", "")
+    extra = f" text={text!r}" if text else ""
+    extra += f" value={value!r}" if value else ""
+    print(f"{prefix}[{role}] {name!r}{extra}")
+    for child in node.get("children", []):
+        _dump(child, indent + 1)
+    if indent == 0:
+        pass  # done
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_linux_backend.py
+++ b/tests/test_linux_backend.py
@@ -462,8 +462,8 @@ class TestAtspiBackend:
 class TestKeyTranslation:
     def test_plain_text(self):
         tokens = _parse_keys_to_xdotool("hello")
-        # Each character becomes: type --clearmodifiers <char>
-        assert tokens.count("type") == 5
+        # All plain chars are batched into a single: type --clearmodifiers hello
+        assert tokens == ["type", "--clearmodifiers", "hello"]
 
     def test_special_key(self):
         tokens = _parse_keys_to_xdotool("{ENTER}")
@@ -487,9 +487,8 @@ class TestKeyTranslation:
 
     def test_mixed_input(self):
         tokens = _parse_keys_to_xdotool("abc{ENTER}")
-        # 3 chars + 1 special key
-        assert tokens.count("type") == 3
-        assert "Return" in tokens
+        # 3 chars batched into one type call + 1 special key
+        assert tokens == ["type", "--clearmodifiers", "abc", "key", "Return"]
 
 
 # ---------------------------------------------------------------------------

--- a/uiax/backends/linux/bridge.py
+++ b/uiax/backends/linux/bridge.py
@@ -31,8 +31,10 @@ from uiax.backends.linux.util import (
     atspi_available,
     do_action,
     do_action_by_name,
+    focus_window,
     get_actions,
     get_text_content,
+    get_value,
     mouse_click_atspi,
     require_atspi,
     role_name,
@@ -312,50 +314,59 @@ class LinuxBridge(UIABridge):
             acc.name or role_name(acc),
         )
 
-    def send_keys(self, keys: str, target: dict[str, Any] | None = None) -> None:
-        if target:
-            acc = self._find(target)
-            # Try to focus the element first
-            try:
-                comp = acc.queryComponent()
-                comp.grabFocus()
-            except Exception:
-                pass
-        else:
-            # Focus the attached window
-            root = self._get_root()
-            try:
-                comp = root.queryComponent()
-                comp.grabFocus()
-            except Exception:
-                pass
+    def _focus_target(self, acc: Any | None) -> bool:
+        """
+        Best-effort: focus *acc* so that subsequent keystroke calls land on
+        the right window.
 
-        # Send keys – try AT-SPI first, fall back to xdotool
+        Returns True if AT-SPI ``grabFocus()`` succeeded (indicating an
+        AT-SPI-native app where ``generateKeyboardEvent`` will also work),
+        or False if we had to fall back to ``wmctrl``/xdotool (e.g. GTK4 /
+        XWayland apps where AT-SPI key injection is unreliable).
+        """
+        if acc is None:
+            return False
         try:
-            send_keys_atspi(keys)
+            acc.queryComponent().grabFocus()
+            return True
         except Exception:
-            send_keys_xdotool(keys)
+            pass
+        # grabFocus failed – raise the window via wmctrl/xdotool but always
+        # return False: the caller should use xdotool for key injection too,
+        # since AT-SPI generateKeyboardEvent is unreliable on GTK4/XWayland.
+        try:
+            title = acc.name or ""
+        except Exception:
+            title = ""
+        if title:
+            focus_window(title)
+        return False
+
+    def send_keys(self, keys: str, target: dict[str, Any] | None = None) -> None:
+        acc = self._find(target) if target else self._get_root()
+        atspi_focus = self._focus_target(acc)
+
+        if atspi_focus:
+            # AT-SPI grabFocus worked → use AT-SPI injection
+            try:
+                send_keys_atspi(keys)
+                return
+            except Exception:
+                pass
+        # Fall back to xdotool (handles GTK4/XWayland and any AT-SPI failure)
+        send_keys_xdotool(keys)
 
     def type_text(self, text: str, target: dict[str, Any] | None = None) -> None:
-        if target:
-            acc = self._find(target)
-            try:
-                comp = acc.queryComponent()
-                comp.grabFocus()
-            except Exception:
-                pass
-        else:
-            root = self._get_root()
-            try:
-                comp = root.queryComponent()
-                comp.grabFocus()
-            except Exception:
-                pass
+        acc = self._find(target) if target else self._get_root()
+        atspi_focus = self._focus_target(acc)
 
-        try:
-            type_text_atspi(text)
-        except Exception:
-            type_text_xdotool(text)
+        if atspi_focus:
+            try:
+                type_text_atspi(text)
+                return
+            except Exception:
+                pass
+        type_text_xdotool(text)
 
     def legacy_invoke(self, target: dict[str, Any]) -> None:
         """

--- a/uiax/backends/linux/util.py
+++ b/uiax/backends/linux/util.py
@@ -414,6 +414,35 @@ def _type_char(ch: str) -> None:
     pyatspi.Registry.generateKeyboardEvent(0, ch, pyatspi.KEY_STRING)
 
 
+def focus_window(title: str) -> bool:
+    """
+    Bring a window with the given title into keyboard focus.
+
+    Tries ``wmctrl -a <title>`` first (reliable under most Xorg/XWayland
+    compositors).  Falls back to ``xdotool search --name <title>
+    windowfocus`` if wmctrl is unavailable.  Returns True if either
+    command succeeded, False if neither tool is installed or the window
+    was not found.
+    """
+    import time  # noqa: PLC0415
+    display = os.environ.get("DISPLAY", ":0")
+    env = {**os.environ, "DISPLAY": display}
+    for cmd in (
+        ["wmctrl", "-a", title],
+        ["xdotool", "search", "--name", title, "windowfocus", "--sync"],
+    ):
+        try:
+            result = subprocess.run(
+                cmd, env=env, capture_output=True, timeout=3
+            )
+            if result.returncode == 0:
+                time.sleep(0.15)  # give the WM time to complete the focus
+                return True
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            continue
+    return False
+
+
 def send_keys_xdotool(keys: str) -> None:
     """
     Fallback keystroke injection via xdotool.
@@ -462,7 +491,17 @@ def type_text_xdotool(text: str) -> None:
 
 
 def _parse_keys_to_xdotool(keys: str) -> list[str]:
-    """Convert SendKeys notation into xdotool argument tokens."""
+    """Convert SendKeys notation into xdotool argument tokens.
+
+    xdotool supports chained subcommands in a single invocation, e.g.::
+
+        xdotool key Escape type --clearmodifiers "6*7" key Return
+
+    The key rule: consecutive plain (unmodified) characters must be batched
+    into a *single* ``type --clearmodifiers <text>`` subcommand.  Emitting
+    one ``type`` per character causes xdotool to treat subsequent ``type``
+    tokens as text arguments of the first ``type`` subcommand.
+    """
     _XDOTOOL_MAP: dict[str, str] = {
         "ENTER": "Return", "RETURN": "Return", "TAB": "Tab",
         "ESC": "Escape", "ESCAPE": "Escape", "BACKSPACE": "BackSpace",
@@ -482,11 +521,19 @@ def _parse_keys_to_xdotool(keys: str) -> list[str]:
     i = 0
     length = len(keys)
     modifiers: list[str] = []
+    # Buffer for consecutive plain characters – flushed as one "type" call
+    plain_buf: list[str] = []
+
+    def _flush_plain() -> None:
+        if plain_buf:
+            result.extend(["type", "--clearmodifiers", "".join(plain_buf)])
+            plain_buf.clear()
 
     while i < length:
         ch = keys[i]
 
         if ch in _MOD_XDOTOOL:
+            _flush_plain()
             modifiers.append(_MOD_XDOTOOL[ch])
             i += 1
             continue
@@ -494,8 +541,10 @@ def _parse_keys_to_xdotool(keys: str) -> list[str]:
         if ch == "{":
             end = keys.find("}", i + 1)
             if end == -1:
+                plain_buf.append(ch)
                 i += 1
                 continue
+            _flush_plain()
             key_name = keys[i + 1 : end].upper()
             xkey = _XDOTOOL_MAP.get(key_name, key_name)
             combo = "+".join(modifiers + [xkey])
@@ -506,13 +555,15 @@ def _parse_keys_to_xdotool(keys: str) -> list[str]:
 
         # Literal character
         if modifiers:
+            _flush_plain()
             combo = "+".join(modifiers + [ch])
             result.extend(["key", combo])
             modifiers.clear()
         else:
-            result.extend(["type", "--clearmodifiers", ch])
+            plain_buf.append(ch)
         i += 1
 
+    _flush_plain()
     return result
 
 

--- a/uiax/server.py
+++ b/uiax/server.py
@@ -1,0 +1,18 @@
+"""
+Canonical entry-point for the UIA-X MCP server.
+
+This module re-exports :func:`server.server.main` so that the server can be
+invoked via the ``uiax.server`` namespace:
+
+    python -m uiax.server
+    uiax-server                 # console-scripts entry point
+
+The ``server.server`` module remains importable for backward compatibility.
+"""
+
+from server.server import main  # noqa: F401 – public re-export
+
+__all__ = ["main"]
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Three commits cleaning up several issues found during Linux backend review and live testing.

### 1. `UIAX_*` env var consistency + `uiax.server` namespace (`7d313ab`)
- Rename auth/backend env vars to `UIAX_AUTH` / `UIAX_BACKEND` (legacy aliases kept)
- Add `uiax/server.py` shim so `python -m uiax.server` works as documented
- Fix macOS `ProcessManagerAdapter` wrapping in the factory
- Show actionable startup warning when `python3-pyatspi` is missing on Linux
- README: per-platform quick-start tables, key path table, all stale references replaced

### 2. Add `python3-venv` to Linux quick-start (`74255c7`)
- `apt install` line in README was missing `python3-venv`

### 3. Robust focus + keystroke injection for GTK4/XWayland (`a7885ab`)
- `grabFocus()` returns `atspi_error: 1` on GTK4/XWayland (gnome-calculator on VNC)
- Add `focus_window()` helper: `wmctrl -a` → `xdotool search --name … windowfocus` fallback
- `_focus_target()` returns `bool`; `False` means fall through to xdotool key injection
  (`generateKeyboardEvent` also unreliable on GTK4/XWayland)
- Fix `_parse_keys_to_xdotool`: batch consecutive plain chars into one
  `type --clearmodifiers <text>` token instead of one per character  
  (per-char approach caused xdotool to misparse subsequent subcommands as text arguments)
- Update `TestKeyTranslation` tests to assert the new batched format
- Add `tests/mcp_live_test.py`: end-to-end MCP test that drives gnome-calculator
  via `process_list → select_window → uia_invoke (buttons) → uia_inspect (result)`

### Why didn't CI catch the keystroke bug?
The integration tests use `uia_invoke` (AT-SPI click actions), not `send_keys`.
Docker runs `Xvfb` (native X11), not XWayland — so `grabFocus` works there regardless.
The unit tests were asserting the old, broken per-character token format.